### PR TITLE
Wizard improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^18.0.11",
     "@uidotdev/usehooks": "^2.0.1",
     "ajv": "^8.12.0",
+    "classnames": "^2.3.2",
     "jsonpointer": "^5.0.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -39,7 +39,16 @@
 }
 
 .is-over-dropzone {
-  box-shadow: 0px 0px 18px 3px #f9d739;
-
+  /* box-shadow: 0px 0px 18px 3px #f9d739; */
+  border-radius: 4px;
   animation: glow 1s ease-in-out infinite alternate;
+}
+
+@keyframes glow {
+  from {
+    box-shadow: 0px 0px 18px 3px #f9d739;
+  }
+  to {
+    box-shadow: 0 0 10px 6px #fdcf02;
+  }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -37,3 +37,9 @@
     transform: translateY(0px);
   }
 }
+
+.is-over-dropzone {
+  box-shadow: 0px 0px 18px 3px #f9d739;
+
+  animation: glow 1s ease-in-out infinite alternate;
+}

--- a/src/Icons/LongHorizontalArrow.tsx
+++ b/src/Icons/LongHorizontalArrow.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+function LongHorizontalArrow() {
+  return (
+    <svg width="48" height="22" viewBox="4 6 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M23.0677 11.9929L18.818 7.75739L17.4061 9.17398L19.2415 11.0032L0.932469 11.0012L0.932251 13.0012L19.2369 13.0032L17.4155 14.8308L18.8321 16.2426L23.0677 11.9929Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+export default LongHorizontalArrow

--- a/src/app/hooks/index.ts
+++ b/src/app/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useDragTarget'
 export * from './useDropTarget'
+export * from './useDelayedState'

--- a/src/app/hooks/useDelayedState.ts
+++ b/src/app/hooks/useDelayedState.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState, useRef, useEffect } from 'react'
+
+export default function useDelkayedState(initial, { delay = 300, delayedValue = true }) {
+  const [state, setState] = useState(initial)
+  const [change, setChange] = useState(initial)
+  const timer = useRef(null)
+
+  useEffect(() => {
+    timer.current = setTimeout(function () {
+      setState(change)
+    }, delay)
+
+    return function () {
+      clearTimeout(timer.current)
+      timer.current = null
+    }
+  }, [change, delay, delayedValue])
+
+  const cancel = useCallback((state) => {
+    setState(state)
+    clearTimeout(timer.current)
+    timer.current = null
+  }, [])
+
+  return [state, setChange, cancel]
+}

--- a/src/app/hooks/useDropTarget.ts
+++ b/src/app/hooks/useDropTarget.ts
@@ -5,6 +5,7 @@ import {
   insertControl,
   isDraggableComponent,
   isDraggableUISchemaElement,
+  moveControl,
 } from '../../features/wizard/WizardSlice'
 import { Scopable, UISchemaElement } from '@jsonforms/core'
 import { useAppDispatch } from './reduxHooks'
@@ -12,70 +13,74 @@ import { pathSegmentsToPath, pathToPathSegments, scopeToPathSegments } from '../
 
 export type UseDropTargetProps = {
   child: UISchemaElement
-  uiSchemaPath?: string
+  isPlaceholder?: Boolean
 }
-export const useDropTarget = ({ child, uiSchemaPath }: UseDropTargetProps) => {
+export const useDropTarget = ({ child, isPlaceholder = false }: UseDropTargetProps) => {
   const dispatch = useAppDispatch()
   const [draggedMeta, setDraggedMeta] = useState<DraggableComponent | undefined>()
   const handleDrop = useCallback(
-    (componentMeta: DraggableComponent) => {
+    (componentMeta: DraggableComponent, placeBefore = false) => {
       // @ts-ignore
       dispatch(
         insertControl({
           draggableMeta: componentMeta,
           child,
-          uiSchemaPath,
+          isPlaceholder,
+          placeBefore,
         })
       )
     },
-    [dispatch, child]
+    [dispatch, child, isPlaceholder]
   )
   const handleMove = useCallback(
-    (componentMeta: DraggableComponent | DraggableUISchemaElement) => {
-      const uiSchemaPath: string | undefined = (componentMeta.uiSchema as any)?.path
-      if (isDraggableComponent(componentMeta)) {
-        //TDOD very confusing using the name as path here, we should introduce a path property within DraggableComponent
-        const path = componentMeta.name
-        let pathSegments = path.includes('.') ? pathToPathSegments(path) : [path]
-        const childScope = (child as Scopable).scope,
-          name = pathSegments.pop()
+    (componentMeta: DraggableComponent | DraggableUISchemaElement, placeBefore = false) => {
+      // const uiSchemaPath: string | undefined = (componentMeta.uiSchema as any)?.path
+      dispatch(
+        moveControl({
+          draggableMeta: componentMeta,
+          child,
+          placeBefore,
+        })
+      )
+      // if (isDraggableComponent(componentMeta)) {
+      //   //TDOD very confusing using the name as path here, we should introduce a path property within DraggableComponent
+      //   const path = componentMeta.name
+      //   let pathSegments = path.includes('.') ? pathToPathSegments(path) : [path]
+      //   const childScope = (child as Scopable).scope,
+      //     name = pathSegments.pop()
 
-        //FIXME: the following should not be necessary, but somehow the path is not set correctly, when root path
-        if (pathSegments.length === 0) {
-          pathSegments = [path]
-        }
-        if (childScope && pathSegmentsToPath(scopeToPathSegments(childScope)) === componentMeta.name) {
-          console.info('Dropped on my self, ignoring')
-          return
-        }
+      //   //FIXME: the following should not be necessary, but somehow the path is not set correctly, when root path
+      //   if (pathSegments.length === 0) {
+      //     pathSegments = [path]
+      //   }
+      //   if (childScope && pathSegmentsToPath(scopeToPathSegments(childScope)) === componentMeta.name) {
+      //     console.info('Dropped on my self, ignoring')
+      //     return
+      //   }
 
-        const draggableMeta: DraggableComponent = {
-          ...componentMeta,
-          name,
-        }
-        dispatch(
-          insertControl({
-            draggableMeta,
-            child,
-            remove: {
-              fieldPath: path,
-              layoutPath: uiSchemaPath,
-            },
-          })
-        )
-      } else {
-        if (isDraggableUISchemaElement(componentMeta)) {
-          dispatch(
-            insertControl({
-              draggableMeta: componentMeta,
-              child,
-              remove: {
-                layoutPath: uiSchemaPath,
-              },
-            })
-          )
-        }
-      }
+      //   const draggableMeta: DraggableComponent = {
+      //     ...componentMeta,
+      //     name,
+      //   }
+      //   dispatch(
+      //     moveControl({
+      //       draggableMeta,
+      //       child,
+      //     })
+      //   )
+      // } else {
+      //   if (isDraggableUISchemaElement(componentMeta)) {
+      //     dispatch(
+      //       insertControl({
+      //         draggableMeta: componentMeta,
+      //         child,
+      //         remove: {
+      //           layoutPath: uiSchemaPath,
+      //         },
+      //       })
+      //     )
+      //   }
+      // }
     },
     [dispatch, child]
   )
@@ -85,6 +90,7 @@ export const useDropTarget = ({ child, uiSchemaPath }: UseDropTargetProps) => {
       accept: ['DRAGBOX', 'MOVEBOX'],
       //@ts-ignore
       drop: ({ componentMeta }, monitor) => {
+        console.log(monitor)
         if (monitor.didDrop()) return
         if (monitor.getItemType() === 'MOVEBOX') {
           handleMove(componentMeta)
@@ -112,11 +118,44 @@ export const useDropTarget = ({ child, uiSchemaPath }: UseDropTargetProps) => {
     }),
     [handleDrop, setDraggedMeta]
   )
+  const handleDropAtStart = useCallback(
+    () => ({
+      accept: ['DRAGBOX', 'MOVEBOX'],
+      //@ts-ignore
+      drop: ({ componentMeta }, monitor) => {
+        console.log(monitor)
+        if (monitor.didDrop()) return
+        if (monitor.getItemType() === 'MOVEBOX') {
+          handleMove(componentMeta, true)
+        } else {
+          handleDrop(componentMeta, true)
+        }
+      },
+      hover: ({ componentMeta }, monitor) => {
+        if (monitor.getItemType() === 'MOVEBOX') {
+          const { type, scope, ...rest } = componentMeta?.uiSchema || {}
+          const draggableMeta = {
+            ...componentMeta,
+            name: componentMeta.name ? componentMeta.name.split('.').pop() : 'layout',
+            uiSchema: rest,
+          }
+          setDraggedMeta(draggableMeta)
+          return
+        }
+        setDraggedMeta(componentMeta)
+      },
+      collect: (monitor) => ({
+        isOver: monitor.isOver(),
+        isOverCurrent: monitor.isOver({ shallow: true }),
+      }),
+    }),
+    [handleDrop, setDraggedMeta]
+  )
 
   return {
     handleAllDrop,
+    handleDropAtStart,
     draggedMeta,
     handleDrop,
-    handleMove,
   }
 }

--- a/src/app/hooks/useDropTarget.ts
+++ b/src/app/hooks/useDropTarget.ts
@@ -90,7 +90,6 @@ export const useDropTarget = ({ child, isPlaceholder = false }: UseDropTargetPro
       accept: ['DRAGBOX', 'MOVEBOX'],
       //@ts-ignore
       drop: ({ componentMeta }, monitor) => {
-        console.log(monitor)
         if (monitor.didDrop()) return
         if (monitor.getItemType() === 'MOVEBOX') {
           handleMove(componentMeta)
@@ -123,7 +122,6 @@ export const useDropTarget = ({ child, isPlaceholder = false }: UseDropTargetPro
       accept: ['DRAGBOX', 'MOVEBOX'],
       //@ts-ignore
       drop: ({ componentMeta }, monitor) => {
-        console.log(monitor)
         if (monitor.didDrop()) return
         if (monitor.getItemType() === 'MOVEBOX') {
           handleMove(componentMeta, true)
@@ -156,6 +154,5 @@ export const useDropTarget = ({ child, isPlaceholder = false }: UseDropTargetPro
     handleAllDrop,
     handleDropAtStart,
     draggedMeta,
-    handleDrop,
   }
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -16,3 +16,5 @@ export const store = configureStore({
 export type AppDispatch = typeof store.dispatch
 export type RootState = ReturnType<typeof store.getState>
 export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, RootState, unknown, Action<string>>
+
+function jsonformsgarbagemiddleware() {}

--- a/src/features/AppBar/AppBar.tsx
+++ b/src/features/AppBar/AppBar.tsx
@@ -18,20 +18,30 @@ import { TemplateModalButton } from '../Templates/TemplateModal'
 function MainAppBar() {
   const dispatch = useAppDispatch()
 
-  const editMode = useSelector(selectEditMode)
-  const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(toggleEditMode())
-  }
+  // const editMode = useSelector(selectEditMode)
+  // const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   dispatch(toggleEditMode())
+  // }
   return (
     <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-      <Toolbar>
-        <Typography variant="h6" noWrap component="div">
+      <Toolbar
+        sx={{
+          ' > *': {
+            mr: 2,
+          },
+          ' > button': {
+            mr: 2,
+          },
+        }}
+      >
+        {/* <Typography variant="h6" noWrap component="div">
           <FormattedMessage id="editMode"></FormattedMessage>
-        </Typography>
-        <Switch checked={editMode} onChange={handleToggleEdit} />
-        <LanguageSelector></LanguageSelector>
+        </Typography> */}
+        {/* <Switch checked={editMode} onChange={handleToggleEdit} /> */}
+        <Box sx={{ flexGrow: 1 }}></Box>
         <DarkModeSwitch></DarkModeSwitch>
         <TemplateModalButton>Templates</TemplateModalButton>
+        <LanguageSelector></LanguageSelector>
       </Toolbar>
     </AppBar>
   )

--- a/src/features/AppBar/AppBar.tsx
+++ b/src/features/AppBar/AppBar.tsx
@@ -15,33 +15,44 @@ import Brightness4Icon from '@mui/icons-material/Brightness4'
 import Brightness7Icon from '@mui/icons-material/Brightness7'
 import { toggleColorMode } from './AppBarSlice'
 import { TemplateModalButton } from '../Templates/TemplateModal'
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
 function MainAppBar() {
   const dispatch = useAppDispatch()
 
-  // const editMode = useSelector(selectEditMode)
-  // const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   dispatch(toggleEditMode())
-  // }
+  const editMode = useSelector(selectEditMode)
+  const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(toggleEditMode())
+  }
+
   return (
     <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-      <Toolbar
-        sx={{
-          ' > *': {
-            mr: 2,
-          },
-          ' > button': {
-            mr: 2,
-          },
-        }}
-      >
-        {/* <Typography variant="h6" noWrap component="div">
-          <FormattedMessage id="editMode"></FormattedMessage>
-        </Typography> */}
-        {/* <Switch checked={editMode} onChange={handleToggleEdit} /> */}
-        <Box sx={{ flexGrow: 1 }}></Box>
-        <DarkModeSwitch></DarkModeSwitch>
-        <TemplateModalButton>Templates</TemplateModalButton>
-        <LanguageSelector></LanguageSelector>
+      <Toolbar>
+        <Grid2 container flex={1} alignItems="center">
+          <Grid2 md={6}></Grid2>
+          <Grid2 md={3} sx={{ flexWrap: 'nowrap', display: 'flex' }}>
+            <Typography variant="h6" noWrap component="div">
+              <FormattedMessage id="editMode"></FormattedMessage>
+            </Typography>
+            <Switch checked={editMode} onChange={handleToggleEdit} />
+          </Grid2>
+          <Grid2
+            md={3}
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              ' > *': {
+                mr: 2,
+              },
+              ' > button': {
+                mr: 2,
+              },
+            }}
+          >
+            <DarkModeSwitch></DarkModeSwitch>
+            <TemplateModalButton>Templates</TemplateModalButton>
+            <LanguageSelector></LanguageSelector>
+          </Grid2>
+        </Grid2>
       </Toolbar>
     </AppBar>
   )

--- a/src/features/AppBar/AppBar.tsx
+++ b/src/features/AppBar/AppBar.tsx
@@ -19,10 +19,10 @@ import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
 function MainAppBar() {
   const dispatch = useAppDispatch()
 
-  const editMode = useSelector(selectEditMode)
-  const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(toggleEditMode())
-  }
+  // const editMode = useSelector(selectEditMode)
+  // const handleToggleEdit = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   dispatch(toggleEditMode())
+  // }
 
   return (
     <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
@@ -30,10 +30,10 @@ function MainAppBar() {
         <Grid2 container flex={1} alignItems="center">
           <Grid2 md={6}></Grid2>
           <Grid2 md={3} sx={{ flexWrap: 'nowrap', display: 'flex' }}>
-            <Typography variant="h6" noWrap component="div">
+            {/* <Typography variant="h6" noWrap component="div">
               <FormattedMessage id="editMode"></FormattedMessage>
             </Typography>
-            <Switch checked={editMode} onChange={handleToggleEdit} />
+            <Switch checked={editMode} onChange={handleToggleEdit} /> */}
           </Grid2>
           <Grid2
             md={3}

--- a/src/features/AppBar/LanguageDropdown.tsx
+++ b/src/features/AppBar/LanguageDropdown.tsx
@@ -35,7 +35,7 @@ function LanguageSelector() {
   const locale = useSelector(getSelectedLanguage)
   const dispatch = useDispatch()
   return (
-    <Root sx={{ color: 'white' }}>
+    <Root sx={{ color: 'white', minWidth: 150 }}>
       <Select
         id="language-select"
         value={locale}

--- a/src/features/Templates/TEMPLATES.json
+++ b/src/features/Templates/TEMPLATES.json
@@ -4,7 +4,10 @@
     "Name": "Math Quest",
     "Description": "Eine interaktive Mathe-Quest, die Kindern dabei hilft, ihre mathematischen Fähigkeiten zu verbessern.",
     "Template": {
-      "jsonSchema": {},
+      "jsonSchema": {
+        "type": "object",
+        "properties": {}
+      },
       "uiSchema": { "type": "VerticalLayout", "elements": [] }
     }
   },

--- a/src/features/Templates/TemplateGrid.tsx
+++ b/src/features/Templates/TemplateGrid.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react'
 import useTemplates from './useTemplates'
 import { LayersOutlined } from '@mui/icons-material'
 import TEMPLATES from './TEMPLATES.json'
-import { template } from 'lodash'
+
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
 import { Button, Paper, Typography } from '@mui/material'
 import { useHover } from '@uidotdev/usehooks'

--- a/src/features/Templates/useTemplates.tsx
+++ b/src/features/Templates/useTemplates.tsx
@@ -6,7 +6,13 @@ const blankTemplate = {
   Name: 'blank Template',
   Description: 'start fresh',
   Category: '',
-  Template: { jsonSchema: {}, uiSchema: { type: 'VerticalLayout', elements: [] } },
+  Template: {
+    jsonSchema: {
+      type: 'object',
+      properties: {},
+    },
+    uiSchema: { type: 'VerticalLayout', elements: [] },
+  },
 }
 
 const COMBINED_TEMPLATES = [blankTemplate, ...TEMPLATES]

--- a/src/features/Templates/useTemplates.tsx
+++ b/src/features/Templates/useTemplates.tsx
@@ -24,7 +24,6 @@ function useTemplates() {
   }
   const categories = useMemo(() => ['all Templates'].concat(TEMPLATES.map((t) => t.Category)), [])
   const templates = useMemo(() => {
-    console.log(TEMPLATES)
     const combined = COMBINED_TEMPLATES
 
     return combined.filter((t) => {

--- a/src/features/ToolSettings/ToolSettingsView.tsx
+++ b/src/features/ToolSettings/ToolSettingsView.tsx
@@ -10,7 +10,7 @@ function ToolSettings() {
   const selectedElementJsonSchema = useSelector(selectSelectedElementJsonSchema)
   const UIElementFromSelection = useSelector(selectUIElementFromSelection)
   const { handleChange, toolSettingsJsonSchema, tooldataBuffer } = useToolSettings()
-  console.log(toolSettingsJsonSchema)
+
   return (
     <div>
       {!!toolSettingsJsonSchema && !!tooldataBuffer && (

--- a/src/features/ToolSettings/useToolSettings.tsx
+++ b/src/features/ToolSettings/useToolSettings.tsx
@@ -14,7 +14,7 @@ function useToolSettings() {
   const UIElementFromSelection = useSelector(selectUIElementFromSelection)
   const selectedElementJsonSchema = useSelector(selectSelectedElementJsonSchema)
   const prevSelectedKey = useRef(null)
-  console.log({ selectedElementJsonSchema, UIElementFromSelection })
+
   const toolSettings = useMemo(
     () =>
       selectedElementJsonSchema

--- a/src/features/TrashDroparea/TrashDroparea.tsx
+++ b/src/features/TrashDroparea/TrashDroparea.tsx
@@ -4,14 +4,14 @@ import { Box } from '@mui/material'
 import React, { useCallback, useRef } from 'react'
 import { useDragDropManager, useDragLayer, useDrop } from 'react-dnd'
 import { useAppDispatch } from '../../app/hooks/reduxHooks'
-import { removeFieldAndLayout } from '../wizard/WizardSlice'
+import { DraggableComponent, removeFieldOrLayout } from '../wizard/WizardSlice'
 
 const TrashDroparea = () => {
   const dispatch = useAppDispatch()
 
   const handleRemove = useCallback(
-    (key) => {
-      dispatch(removeFieldAndLayout({ path: key }))
+    (componentMeta: DraggableComponent) => {
+      dispatch(removeFieldOrLayout({ componentMeta }))
     },
     [dispatch]
   )
@@ -25,7 +25,7 @@ const TrashDroparea = () => {
       //   console.log('drop')
       // }
       if (monitor.getItemType() === 'MOVEBOX') {
-        handleRemove(componentMeta.name)
+        handleRemove(componentMeta)
       } else {
         console.log('somethign other ')
       }
@@ -35,12 +35,15 @@ const TrashDroparea = () => {
       isOver: monitor.isOver(),
     }),
   })
+  if (!isDragging) {
+    return null
+  }
 
   return (
     <Box
       ref={drop}
       sx={{
-        position: 'absolute',
+        position: 'fixed',
         right: 200,
         top: 100,
         width: 180,

--- a/src/features/TrashDroparea/TrashDroparea.tsx
+++ b/src/features/TrashDroparea/TrashDroparea.tsx
@@ -21,9 +21,6 @@ const TrashDroparea = () => {
     accept: ['DRAGBOX', 'MOVEBOX'],
     //@ts-ignore
     drop: ({ componentMeta }, monitor) => {
-      // if (monitor.didDrop()) {
-      //   console.log('drop')
-      // }
       if (monitor.getItemType() === 'MOVEBOX') {
         handleRemove(componentMeta)
       } else {

--- a/src/features/TrashDroparea/TrashDroparea.tsx
+++ b/src/features/TrashDroparea/TrashDroparea.tsx
@@ -41,7 +41,7 @@ const TrashDroparea = () => {
       ref={drop}
       sx={{
         position: 'absolute',
-        right: 100,
+        right: 200,
         top: 100,
         width: 180,
         height: 180,

--- a/src/features/home/RightDrawer.tsx
+++ b/src/features/home/RightDrawer.tsx
@@ -6,7 +6,6 @@ import Toolbar from '@mui/material/Toolbar'
 
 import { useSelector } from 'react-redux'
 import {
-  removeFieldAndLayout,
   renameField,
   selectElement,
   selectJsonSchema,
@@ -40,12 +39,12 @@ export const FieldNameEditor: React.FC<{ path: string }> = ({ path }) => {
     setEditMode(false)
   }, [pathSegments, setNewFieldName, setEditMode])
 
-  const handleRemove = useCallback(() => {
-    // @ts-ignore
-    dispatch(removeFieldAndLayout({ path }))
-    // @ts-ignore
-    dispatch(selectElement(undefined))
-  }, [dispatch, path])
+  // const handleRemove = useCallback(() => {
+  //   // @ts-ignore
+  //   dispatch(removeFieldAndLayout({ path }))
+  //   // @ts-ignore
+  //   dispatch(selectElement(undefined))
+  // }, [dispatch, path])
   const handleRenameOrSetEditMode = useCallback(() => {
     if (editMode) {
       const pathSegments = path?.split('.') || []
@@ -97,9 +96,9 @@ export const FieldNameEditor: React.FC<{ path: string }> = ({ path }) => {
           <IconButton onClick={handleRenameOrSetEditMode}>{editMode ? <Save /> : <Edit />}</IconButton>
         </Grid>
         <Grid item>
-          <IconButton onClick={() => handleRemove()}>
+          {/* <IconButton onClick={() => handleRemove()}>
             <Delete />
-          </IconButton>
+          </IconButton> */}
         </Grid>
       </Grid>
     </>

--- a/src/features/tools/DragableJSONSchemaComponents.tsx
+++ b/src/features/tools/DragableJSONSchemaComponents.tsx
@@ -142,6 +142,8 @@ export const basicDraggableComponents: DraggableElement[] = [
     ToolIcon: ArrowRightAlt,
     uiSchema: {
       type: 'HorizontalLayout',
+      //@ts-ignore
+      elements: [],
     },
   },
   {
@@ -149,6 +151,9 @@ export const basicDraggableComponents: DraggableElement[] = [
     ToolIcon: ArrowDownward,
     uiSchema: {
       type: 'HorizontalLayout',
+      //@ts-ignore
+      label: 'Vertikales Layout',
+      elements: [],
     },
   },
 
@@ -165,7 +170,7 @@ export const basicDraggableComponents: DraggableElement[] = [
       label: 'Gruppe',
       elements: [
         {
-          type: 'HorizontalLayout',
+          type: 'VerticalLayout',
           elements: [],
         },
       ],

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -12,7 +12,7 @@ import LeftDrawer from '../home/LeftDrawer'
 import { extendUiSchemaWithPath } from '../../utils/uiSchemaHelpers'
 import { renderesDropping, renderesBasics } from '../../renderer/Renderers'
 import TrashDroparea from '../TrashDroparea/TrashDroparea'
-import { Container } from '@mui/material'
+import { Container, Paper } from '@mui/material'
 
 function Wizard() {
   const [data, setData] = useState<any>({})
@@ -32,15 +32,17 @@ function Wizard() {
       <MainAppBar></MainAppBar>
       <LeftDrawer></LeftDrawer>
       <Container maxWidth="md">
-        <JsonForms
-          data={data}
-          renderers={[...materialRenderers, ...renderesBasics, ...renderesDropping]}
-          cells={materialCells}
-          onChange={handleFormChange}
-          schema={jsonSchema}
-          uischema={uiSchemaWithPath}
-          readonly={true}
-        />
+        <Paper sx={{ p: 4, m: 4 }} elevation={12} square>
+          <JsonForms
+            data={data}
+            renderers={[...materialRenderers, ...renderesBasics, ...renderesDropping]}
+            cells={materialCells}
+            onChange={handleFormChange}
+            schema={jsonSchema}
+            uischema={uiSchemaWithPath}
+            readonly={true}
+          />
+        </Paper>
       </Container>
       {/* <FormControlLabel
         label="aaaaaaaaaaaaaaa        sa    asa"

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -37,7 +37,7 @@ function Wizard() {
         onChange={handleFormChange}
         schema={jsonSchema}
         uischema={uiSchemaWithPath}
-        readonly={editMode}
+        readonly={true}
       />
       {/* <FormControlLabel
         label="aaaaaaaaaaaaaaa        sa    asa"

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -26,7 +26,7 @@ function Wizard() {
   )
   const jsonSchema = useAppSelector(selectJsonSchema)
   const uiSchema = useAppSelector(selectUiSchema)
-  const editMode = useAppSelector(selectEditMode)
+
   const uiSchemaWithPath = useMemo(() => extendUiSchemaWithPath(uiSchema), [uiSchema])
   const listRef = useRef<null | HTMLDivElement>(null)
   const { updatePosition } = useScroll(listRef)

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -12,6 +12,7 @@ import LeftDrawer from '../home/LeftDrawer'
 import { extendUiSchemaWithPath } from '../../utils/uiSchemaHelpers'
 import { renderesDropping, renderesBasics } from '../../renderer/Renderers'
 import TrashDroparea from '../TrashDroparea/TrashDroparea'
+import { Container } from '@mui/material'
 
 function Wizard() {
   const [data, setData] = useState<any>({})
@@ -30,15 +31,17 @@ function Wizard() {
     <Box component={'main'} sx={{ display: 'flex', flexGrow: 1, p: 3, mt: 8 }}>
       <MainAppBar></MainAppBar>
       <LeftDrawer></LeftDrawer>
-      <JsonForms
-        data={data}
-        renderers={[...materialRenderers, ...renderesBasics, ...renderesDropping]}
-        cells={materialCells}
-        onChange={handleFormChange}
-        schema={jsonSchema}
-        uischema={uiSchemaWithPath}
-        readonly={true}
-      />
+      <Container maxWidth="md">
+        <JsonForms
+          data={data}
+          renderers={[...materialRenderers, ...renderesBasics, ...renderesDropping]}
+          cells={materialCells}
+          onChange={handleFormChange}
+          schema={jsonSchema}
+          uischema={uiSchemaWithPath}
+          readonly={true}
+        />
+      </Container>
       {/* <FormControlLabel
         label="aaaaaaaaaaaaaaa        sa    asa"
         labelPlacement="top"

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { JsonFormsCore } from '@jsonforms/core'
 import { materialCells, materialRenderers } from '@jsonforms/material-renderers'
 import { useAppSelector } from '../../app/hooks/reduxHooks'
@@ -13,6 +13,8 @@ import { extendUiSchemaWithPath } from '../../utils/uiSchemaHelpers'
 import { renderesDropping, renderesBasics } from '../../renderer/Renderers'
 import TrashDroparea from '../TrashDroparea/TrashDroparea'
 import { Container, Paper } from '@mui/material'
+import { useScroll } from './useScroll'
+import { useDragDropManager } from 'react-dnd'
 
 function Wizard() {
   const [data, setData] = useState<any>({})
@@ -26,6 +28,19 @@ function Wizard() {
   const uiSchema = useAppSelector(selectUiSchema)
   const editMode = useAppSelector(selectEditMode)
   const uiSchemaWithPath = useMemo(() => extendUiSchemaWithPath(uiSchema), [uiSchema])
+  const listRef = useRef<null | HTMLDivElement>(null)
+  const { updatePosition } = useScroll(listRef)
+
+  const dragDropManager = useDragDropManager()
+  const monitor = dragDropManager.getMonitor()
+
+  useEffect(() => {
+    const unsubscribe = monitor.subscribeToOffsetChange(() => {
+      const offset = monitor.getSourceClientOffset()?.y as number
+      updatePosition(offset)
+    })
+    return unsubscribe
+  }, [monitor, updatePosition])
 
   return (
     <Box component={'main'} sx={{ display: 'flex', flexGrow: 1, p: 3, mt: 8 }}>

--- a/src/features/wizard/Wizard.tsx
+++ b/src/features/wizard/Wizard.tsx
@@ -10,9 +10,6 @@ import { JsonForms } from '@jsonforms/react'
 import RightDrawer from '../home/RightDrawer'
 import LeftDrawer from '../home/LeftDrawer'
 import { extendUiSchemaWithPath } from '../../utils/uiSchemaHelpers'
-import { FormControl, FormControlLabel, FormGroup, FormHelperText, Hidden } from '@mui/material'
-import { CheckBox } from '@mui/icons-material'
-import MaterialAlertRenderer, { materialAlertRendererTester } from '../../renderer/MaterialAlertRenderer'
 import { renderesDropping, renderesBasics } from '../../renderer/Renderers'
 import TrashDroparea from '../TrashDroparea/TrashDroparea'
 
@@ -63,7 +60,7 @@ function Wizard() {
         }
       ></FormControlLabel> */}
       <RightDrawer></RightDrawer>
-<TrashDroparea></TrashDroparea>
+      <TrashDroparea></TrashDroparea>
     </Box>
   )
 }

--- a/src/features/wizard/WizardSlice.ts
+++ b/src/features/wizard/WizardSlice.ts
@@ -278,7 +278,7 @@ export const jsonFormsEditSlice = createSlice({
       if (scope) {
         state.jsonSchema = deeplyRemoveNestedProperty(state.jsonSchema, pathSegmentsToPath(scopeToPathSegments(scope)))
       }
-      state.jsonSchema = collectSchemaGarbage(state.jsonSchema, state.uiSchema)
+      // state.jsonSchema = collectSchemaGarbage(state.jsonSchema, state.uiSchema)
     },
     renameField: (state: JsonFormsEditState, action: PayloadAction<{ path: string; newFieldName: string }>) => {
       //TODO: handle renaming key within data produced by the form in the current session
@@ -353,9 +353,9 @@ export const jsonFormsEditSlice = createSlice({
       if (isDraggableComponent(draggableMeta)) {
         // TODO scope is not set correctly
 
-        //   const deepestGroupPath = getDeepestGroupPath(child.structurePath, state.uiSchema)
+        // const deepestGroupPath = getDeepestGroupPath(child.structurePath, state.uiSchema)
 
-        //   let schema = pathSegmentsToScope(deepestGroupPath)
+        // let schema = pathSegmentsToScope(deepestGroupPath)
         uiSchema = getUiSchemaWithFlatScope(draggableMeta, [], newKey)
 
         //   // // TODO add createsOwnScope to draggableMeta

--- a/src/features/wizard/WizardSlice.ts
+++ b/src/features/wizard/WizardSlice.ts
@@ -24,8 +24,6 @@ import { ScopableUISchemaElement } from '../../types'
 import { exampleInitialState2, JsonFormsEditState } from './exampleState'
 import jsonpointer from 'jsonpointer'
 import { OverridableComponent } from '@mui/material/OverridableComponent'
-import { cloneDeep, findLast, findLastIndex, last } from 'lodash'
-import collectSchemaGarbage from '../../utils/collectSchemaGargabe'
 
 export type DraggableMeta = {
   name: string
@@ -204,33 +202,33 @@ const getUiSchemaWithFlatScope: (
   }
 }
 
-const getDeepestGroupPath = (structurePath: string, uiSchema: any): string[] => {
-  const structurePathSegments = pathToPathSegments(structurePath)
-  const siblingRemoved = structurePathSegments.slice(0, structurePathSegments.length - 2)
-  // const pathPairs = siblingRemoved.reduce((prev, curr, index, array) => {
-  //   if (!isNaN(parseInt(curr))) return prev
-  //   return [...prev, [curr, parseInt(array[index + 1])]]
-  // }, [])
-  const deepestGroupIndex = findLastIndex(siblingRemoved, (pair) => pair === 'Group')
-  const deepestGroup = siblingRemoved.slice(0, deepestGroupIndex + 2)
+// const getDeepestGroupPath = (structurePath: string, uiSchema: any): string[] => {
+//   const structurePathSegments = pathToPathSegments(structurePath)
+//   const siblingRemoved = structurePathSegments.slice(0, structurePathSegments.length - 2)
+//   // const pathPairs = siblingRemoved.reduce((prev, curr, index, array) => {
+//   //   if (!isNaN(parseInt(curr))) return prev
+//   //   return [...prev, [curr, parseInt(array[index + 1])]]
+//   // }, [])
+//   const deepestGroupIndex = findLastIndex(siblingRemoved, (pair) => pair === 'Group')
+//   const deepestGroup = siblingRemoved.slice(0, deepestGroupIndex + 2)
 
-  let schemaPath = []
-  deepestGroup.reduce((prev, curr) => {
-    let index = parseInt(curr)
-    if (isNaN(index)) return prev
-    let element = prev[index]
-    if (element.type === 'Group' && element.label) {
-      schemaPath.push(element.label)
-    }
-    if (element.elements) {
-      return element.elements
-    }
-    return element
-  }, uiSchema.elements)
-  console.log(current(uiSchema))
+//   let schemaPath = []
+//   deepestGroup.reduce((prev, curr) => {
+//     let index = parseInt(curr)
+//     if (isNaN(index)) return prev
+//     let element = prev[index]
+//     if (element.type === 'Group' && element.label) {
+//       schemaPath.push(element.label)
+//     }
+//     if (element.elements) {
+//       return element.elements
+//     }
+//     return element
+//   }, uiSchema.elements)
+//   // console.log(current(uiSchema))
 
-  return schemaPath
-}
+//   return schemaPath
+// }
 
 export const jsonFormsEditSlice = createSlice({
   name: 'jsonFormEdit',
@@ -372,6 +370,7 @@ export const jsonFormsEditSlice = createSlice({
         state.jsonSchema.properties[newKey] = draggableMeta.jsonSchemaElement
       }
       oldUISchemaElements.splice(targetIndex, 0, uiSchema)
+      // buildSchemaFromUISchema(state.uiSchema)
     },
 
     moveControl: (
@@ -433,3 +432,27 @@ export const {
 } = jsonFormsEditSlice.actions
 
 export default jsonFormsEditSlice.reducer
+
+function buildSchemaFromUISchema(uiSchema) {
+  const newSchema: JsonSchema = {}
+  console.log(current(uiSchema))
+  const allScopes = mapUiSchemaToJSONSchema(uiSchema, newSchema)
+
+  exampleInitialState2.jsonSchema = newSchema
+  return newSchema
+}
+
+function mapUiSchemaToJSONSchema(uiSchema, newSchema) {
+  // we only care about groups and scopaable elements
+
+  if (uiSchema.type === 'Group') {
+    newSchema.type = 'object'
+    newSchema.id = uiSchema.label
+    newSchema.properties = {}
+  }
+  if (uiSchema.scope) {
+    newSchema.type = 'object'
+    newSchema.id = uiSchema.label
+    newSchema.properties = {}
+  }
+}

--- a/src/features/wizard/WizardSlice.ts
+++ b/src/features/wizard/WizardSlice.ts
@@ -372,10 +372,12 @@ export const jsonFormsEditSlice = createSlice({
       // get the name of the new element
       let newKey = draggableMeta.name
       for (let i = 1; state.jsonSchema.properties[newKey] !== undefined; i++) {
-        newKey = `${newKey}_${i}`
+        newKey = `${draggableMeta.name}_${i}`
       }
       let uiSchema = draggableMeta.uiSchema
       if (isDraggableComponent(draggableMeta)) {
+        // TODO scope is not set correctly
+
         //   const deepestGroupPath = getDeepestGroupPath(child.structurePath, state.uiSchema)
 
         //   let schema = pathSegmentsToScope(deepestGroupPath)

--- a/src/features/wizard/exampleState.ts
+++ b/src/features/wizard/exampleState.ts
@@ -139,18 +139,27 @@ export const exampleInitialState2: JsonFormsEditState = {
   jsonSchema: {
     type: 'object',
     properties: {
-      Radio: {
-        type: 'string',
-        enum: ['One', 'Two', 'Three'],
-      },
-
-      multiEnum: {
-        type: 'array',
-
-        uniqueItems: true,
-        items: {
-          type: 'string',
-          enum: ['foo', 'bar', 'foobar'],
+      address: {
+        type: 'object',
+        properties: {
+          created: {
+            type: 'string',
+            format: 'date-time',
+          },
+          street: {
+            type: 'string',
+          },
+          city: {
+            type: 'string',
+          },
+          zip: {
+            type: 'string',
+            pattern: '[0-9]{5}',
+          },
+          country: {
+            type: 'string',
+            enum: ['Germany', 'France', 'UK', 'USA', 'Italy', 'Spain'],
+          },
         },
       },
     },
@@ -159,16 +168,36 @@ export const exampleInitialState2: JsonFormsEditState = {
     type: 'VerticalLayout',
     elements: [
       {
-        type: 'Control',
-        scope: '#/properties/Radio',
-        label: 'Radio Buttons mit langem Label',
-        options: { format: 'radio' },
-      },
-      {
-        type: 'Control',
-        label: 'Radio Buttons mit langem Label',
-        name: 'multiEnum',
-        scope: '#/properties/multiEnum',
+        type: 'Group',
+        label: 'address',
+
+        elements: [
+          {
+            type: 'VerticalLayout',
+            elements: [
+              {
+                type: 'Control',
+                scope: '#/properties/address/properties/created',
+              },
+              {
+                type: 'Control',
+                scope: '#/properties/address/properties/street',
+              },
+              {
+                type: 'Control',
+                scope: '#/properties/address/properties/city',
+              },
+              {
+                type: 'Control',
+                scope: '#/properties/address/properties/zip',
+              },
+              {
+                type: 'Control',
+                scope: '#/properties/address/properties/country',
+              },
+            ],
+          },
+        ],
       },
     ],
   },

--- a/src/features/wizard/exampleState.ts
+++ b/src/features/wizard/exampleState.ts
@@ -138,67 +138,7 @@ export const exampleInitialState2: JsonFormsEditState = {
   editMode: false,
   jsonSchema: {
     type: 'object',
-    properties: {
-      address: {
-        type: 'object',
-        properties: {
-          created: {
-            type: 'string',
-            format: 'date-time',
-          },
-          street: {
-            type: 'string',
-          },
-          city: {
-            type: 'string',
-          },
-          zip: {
-            type: 'string',
-            pattern: '[0-9]{5}',
-          },
-          country: {
-            type: 'string',
-            enum: ['Germany', 'France', 'UK', 'USA', 'Italy', 'Spain'],
-          },
-        },
-      },
-    },
+    properties: {},
   },
-  uiSchema: {
-    type: 'VerticalLayout',
-    elements: [
-      {
-        type: 'Group',
-        label: 'address',
-
-        elements: [
-          {
-            type: 'VerticalLayout',
-            elements: [
-              {
-                type: 'Control',
-                scope: '#/properties/address/properties/created',
-              },
-              {
-                type: 'Control',
-                scope: '#/properties/address/properties/street',
-              },
-              {
-                type: 'Control',
-                scope: '#/properties/address/properties/city',
-              },
-              {
-                type: 'Control',
-                scope: '#/properties/address/properties/zip',
-              },
-              {
-                type: 'Control',
-                scope: '#/properties/address/properties/country',
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
+  uiSchema: { type: 'VerticalLayout', elements: [] },
 }

--- a/src/features/wizard/useScroll.ts
+++ b/src/features/wizard/useScroll.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState, useRef, RefObject } from 'react'
+
+const BOUND_HEIGHT_BOT = 250
+const BOUND_HEIGHT_TOP = 180
+
+function getScrollDirection({
+  position,
+  upperBounds = Infinity,
+  lowerBounds = -Infinity,
+}: {
+  position: number | undefined
+  upperBounds: number
+  lowerBounds: number
+}): number {
+  if (position === undefined) {
+    return 0
+  }
+  if (position > lowerBounds - BOUND_HEIGHT_BOT) {
+    return 1 - (lowerBounds - position) / BOUND_HEIGHT_BOT
+  }
+  if (position < upperBounds + BOUND_HEIGHT_TOP) {
+    return (1 - (upperBounds + position) / BOUND_HEIGHT_TOP) * -1
+  }
+  return 0
+}
+
+export const useScroll = (ref: RefObject<HTMLElement | null>) => {
+  const [position, setPosition] = useState<number>(window.innerHeight / 2)
+
+  const scrollTimer = useRef<null | NodeJS.Timeout>(null)
+
+  const scrollSpeed = 5
+
+  const direction = getScrollDirection({
+    position,
+    upperBounds: 0,
+    lowerBounds: window.innerHeight,
+  })
+  //   console.log(window.outerHeight, window.innerHeight, position)
+  useEffect(() => {
+    // const ref = document.getElementById('wizard')
+
+    if (direction !== 0) {
+      scrollTimer.current = setInterval(() => {
+        window.scrollBy(0, scrollSpeed * direction)
+      }, 1)
+    }
+    return () => {
+      if (scrollTimer.current) {
+        clearInterval(scrollTimer.current)
+      }
+    }
+  }, [direction, ref, scrollSpeed])
+
+  return { updatePosition: setPosition } as const
+}

--- a/src/renderer/LayoutElement.tsx
+++ b/src/renderer/LayoutElement.tsx
@@ -137,15 +137,24 @@ const LayoutElement = ({
       )}
       {!isDragging && (
         <>
-          <Grid key={key} item ref={dropRef} xs onClick={handleSelect} sx={{ padding: 4, backgroundColor: 'blue' }}>
-            <Paper
-              elevation={selectedKey === key ? 4 : 0}
+          <Grid key={key} item ref={dropRef} xs onClick={handleSelect}>
+            <Box
+              // elevation={selectedKey === key ? 4 : 0}
               sx={{
                 flexGrow: 1,
                 display: isDragging ? 'none' : 'flex',
                 backgroundColor: (theme) => (selectedKey === key ? theme.palette.primary.light : 'none'),
                 padding: (theme) => theme.spacing(1, 2),
-                cursor: 'grab',
+                cursor: 'grab !important',
+                ' * ': {
+                  cursor: 'grab !important',
+                },
+                ' > *': {
+                  flexGrow: 1,
+                },
+                ':hover': {
+                  backgroundColor: (theme) => theme.palette.primary.main,
+                },
               }}
               ref={dragRef}
             >
@@ -157,7 +166,7 @@ const LayoutElement = ({
                 renderers={renderers}
                 cells={cells}
               />
-            </Paper>
+            </Box>
           </Grid>
           <Paper
             sx={{

--- a/src/renderer/LayoutElement.tsx
+++ b/src/renderer/LayoutElement.tsx
@@ -191,7 +191,6 @@ function LayoutDropArea({ isOverCurrent, dropRef, anythingDragging }) {
   const [dragging, setDragging, cancel] = useDelkayedState(false, { delay: 10, delayedValue: true })
 
   useEffect(() => {
-    console.log(anythingDragging)
     setDragging(anythingDragging)
     if (anythingDragging !== dragging && !anythingDragging) {
       cancel(false)

--- a/src/renderer/LayoutElement.tsx
+++ b/src/renderer/LayoutElement.tsx
@@ -1,0 +1,184 @@
+import type { LabelElement, UISchemaElement } from '@jsonforms/core'
+import {
+  composeWithUi,
+  ControlElement,
+  getAjv,
+  getSchema,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  OwnPropsOfRenderer,
+  Resolve,
+} from '@jsonforms/core'
+import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react'
+import { Box, Grid, IconButton, Paper } from '@mui/material'
+import Ajv from 'ajv'
+import isEmpty from 'lodash/isEmpty'
+import React, { ComponentType, FC, MouseEventHandler, ReactNode, useCallback, useMemo } from 'react'
+import { useDrop } from 'react-dnd'
+import { useAppDispatch } from '../app/hooks/reduxHooks'
+import {
+  removeFieldAndLayout,
+  selectEditMode,
+  selectElement,
+  selectSelectedElementKey,
+} from '../features/wizard/WizardSlice'
+import { useSelector } from 'react-redux'
+import { Delete } from '@mui/icons-material'
+import DropTargetFormsPreview from '../features/dragAndDrop/DropTargetFormsPreview'
+import { useDragTarget, useDropTarget } from '../app/hooks'
+
+export type RemoveWrapperProps = { editMode: boolean; handleRemove: MouseEventHandler; children: ReactNode }
+const RemoveWrapper: FC<RemoveWrapperProps> = ({ editMode, handleRemove, children }) => {
+  return (
+    <>
+      {editMode ? (
+        <Grid container>
+          <Grid item xs={11}>
+            {children}
+          </Grid>
+          <Grid item xs={1}>
+            <IconButton onClick={handleRemove}>
+              <Delete></Delete>
+            </IconButton>
+          </Grid>
+        </Grid>
+      ) : (
+        children
+      )}
+    </>
+  )
+}
+
+type LayoutElementProps = {
+  index: number
+  direction: 'row' | 'column'
+  schema: JsonSchema
+  visible: boolean
+  path: string
+  enabled: boolean
+  element: UISchemaElement
+  renderers?: JsonFormsRendererRegistryEntry[]
+  cells?: JsonFormsCellRendererRegistryEntry[]
+  parent: UISchemaElement[]
+}
+
+const LayoutElement = ({
+  index,
+  direction,
+
+  schema,
+  path,
+  enabled,
+  element: child,
+  cells,
+  parent,
+  renderers,
+}: LayoutElementProps) => {
+  const ctx = useJsonForms()
+  const state = { jsonforms: ctx }
+  const rootSchema = getSchema(state)
+  //const rootData = getData(state)
+  const dispatch = useAppDispatch()
+  const editMode = useSelector(selectEditMode)
+  const selectedKey = useSelector(selectSelectedElementKey)
+  const controlName = useMemo<string | undefined>(
+    () => (child.type === 'Control' ? composeWithUi(child as ControlElement, path) : undefined),
+    [child, path]
+  )
+
+  const resolvedSchema = useMemo<JsonSchema | undefined>(
+    () => Resolve.schema(schema || rootSchema, (child as ControlElement).scope, rootSchema),
+
+    [schema, rootSchema, child]
+  )
+
+  const key = useMemo<string>(
+    () => (controlName ? controlName : `${child.type}-${index}`),
+    [controlName, index, child.type]
+  )
+  const isGroup = useMemo<boolean>(() => child.type === 'Group', [child])
+  const { handleAllDrop, draggedMeta } = useDropTarget({ child })
+
+  const [{ isDragging }, dragRef] = useDragTarget({ child, name: controlName, resolvedSchema })
+
+  const [{ isOver: isOver1, isOverCurrent: isOverCurrent1 }, dropRef] = useDrop(handleAllDrop, [handleAllDrop])
+  const [{ isOver: isOver2, isOverCurrent: isOverCurrent2 }, dropRef2] = useDrop(handleAllDrop, [handleAllDrop])
+  const isOver = isOver1 || isOver2
+  const isOverCurrent = isOverCurrent1 || isOverCurrent2
+  const handleSelect = useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      event.stopPropagation()
+      // @ts-ignore
+      dispatch(selectElement(key))
+    },
+    [dispatch, key]
+  )
+
+  const handleRemove = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      event.stopPropagation()
+      dispatch(removeFieldAndLayout({ path: key }))
+    },
+    [dispatch, key]
+  )
+
+  return (
+    <>
+      <Grid key={key} item ref={dropRef} xs onClick={handleSelect}>
+        <Paper
+          elevation={selectedKey === key ? 4 : 0}
+          sx={{
+            flexGrow: 1,
+            display: isDragging ? 'none' : 'flex',
+            backgroundColor: (theme) => (selectedKey === key ? theme.palette.primary.light : 'none'),
+            padding: (theme) => theme.spacing(1, 2),
+            cursor: 'grab',
+          }}
+          ref={dragRef}
+        >
+          {!isGroup && (
+            <RemoveWrapper handleRemove={handleRemove} editMode={editMode}>
+              <JsonFormsDispatch
+                uischema={child}
+                schema={schema}
+                path={path}
+                enabled={enabled}
+                renderers={renderers}
+                cells={cells}
+              />
+            </RemoveWrapper>
+          )}
+          {isGroup && (
+            <JsonFormsDispatch
+              uischema={child}
+              schema={schema}
+              path={path}
+              enabled={enabled}
+              renderers={renderers}
+              cells={cells}
+            />
+          )}
+        </Paper>
+      </Grid>
+      <Paper
+        sx={{
+          border: 'none',
+          opacity: isOver ? '1.0' : '0.2',
+          minWidth: '2em',
+          minHeight: '1.5em',
+          // bgcolor: (theme) => (isOver ?  theme. : 'none'),
+        }}
+        ref={dropRef2}
+      >
+        {isOver && isOverCurrent && draggedMeta ? (
+          <Paper sx={{ padding: (theme) => theme.spacing(1, 2), bgcolor: (theme) => theme.palette.secondary.light }}>
+            <DropTargetFormsPreview metadata={draggedMeta} />
+          </Paper>
+        ) : null}
+      </Paper>
+    </>
+  )
+}
+
+export default LayoutElement

--- a/src/renderer/LayoutElement.tsx
+++ b/src/renderer/LayoutElement.tsx
@@ -17,12 +17,7 @@ import isEmpty from 'lodash/isEmpty'
 import React, { ComponentType, FC, MouseEventHandler, ReactNode, useCallback, useMemo } from 'react'
 import { useDrop } from 'react-dnd'
 import { useAppDispatch } from '../app/hooks/reduxHooks'
-import {
-  removeFieldAndLayout,
-  selectEditMode,
-  selectElement,
-  selectSelectedElementKey,
-} from '../features/wizard/WizardSlice'
+import { selectEditMode, selectElement, selectSelectedElementKey } from '../features/wizard/WizardSlice'
 import { useSelector } from 'react-redux'
 import { Delete } from '@mui/icons-material'
 import DropTargetFormsPreview from '../features/dragAndDrop/DropTargetFormsPreview'
@@ -98,12 +93,13 @@ const LayoutElement = ({
     [controlName, index, child.type]
   )
   const isGroup = useMemo<boolean>(() => child.type === 'Group', [child])
-  const { handleAllDrop, draggedMeta } = useDropTarget({ child })
+  const { handleAllDrop, handleDropAtStart, draggedMeta } = useDropTarget({ child })
 
   const [{ isDragging }, dragRef] = useDragTarget({ child, name: controlName, resolvedSchema })
 
   const [{ isOver: isOver1, isOverCurrent: isOverCurrent1 }, dropRef] = useDrop(handleAllDrop, [handleAllDrop])
   const [{ isOver: isOver2, isOverCurrent: isOverCurrent2 }, dropRef2] = useDrop(handleAllDrop, [handleAllDrop])
+  const [{ isOver: isOver3, isOverCurrent: isOverCurrent3 }, dropRef3] = useDrop(handleDropAtStart, [handleAllDrop])
   const isOver = isOver1 || isOver2
   const isOverCurrent = isOverCurrent1 || isOverCurrent2
   const handleSelect = useCallback(
@@ -115,30 +111,44 @@ const LayoutElement = ({
     [dispatch, key]
   )
 
-  const handleRemove = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      event.stopPropagation()
-      dispatch(removeFieldAndLayout({ path: key }))
-    },
-    [dispatch, key]
-  )
+  // const handleRemove = useCallback(
+  //   (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  //     event.stopPropagation()
+  //     dispatch(removeFieldAndLayout({ path: key }))
+  //   },
+  //   [dispatch, key]
+  // )
 
   return (
     <>
-      <Grid key={key} item ref={dropRef} xs onClick={handleSelect}>
+      {index === 0 && (
         <Paper
-          elevation={selectedKey === key ? 4 : 0}
           sx={{
-            flexGrow: 1,
-            display: isDragging ? 'none' : 'flex',
-            backgroundColor: (theme) => (selectedKey === key ? theme.palette.primary.light : 'none'),
-            padding: (theme) => theme.spacing(1, 2),
-            cursor: 'grab',
+            border: 'none',
+            opacity: isOver3 ? '1.0' : '0.2',
+            minWidth: '2em',
+            minHeight: '1.5em',
+            // bgcolor: (theme) => (isOver ?  theme. : 'none'),
+            padding: 4,
+            backgroundColor: isOver3 ? 'yellow' : 'red',
           }}
-          ref={dragRef}
-        >
-          {!isGroup && (
-            <RemoveWrapper handleRemove={handleRemove} editMode={editMode}>
+          ref={dropRef3}
+        ></Paper>
+      )}
+      {!isDragging && (
+        <>
+          <Grid key={key} item ref={dropRef} xs onClick={handleSelect} sx={{ padding: 4, backgroundColor: 'blue' }}>
+            <Paper
+              elevation={selectedKey === key ? 4 : 0}
+              sx={{
+                flexGrow: 1,
+                display: isDragging ? 'none' : 'flex',
+                backgroundColor: (theme) => (selectedKey === key ? theme.palette.primary.light : 'none'),
+                padding: (theme) => theme.spacing(1, 2),
+                cursor: 'grab',
+              }}
+              ref={dragRef}
+            >
               <JsonFormsDispatch
                 uischema={child}
                 schema={schema}
@@ -147,36 +157,22 @@ const LayoutElement = ({
                 renderers={renderers}
                 cells={cells}
               />
-            </RemoveWrapper>
-          )}
-          {isGroup && (
-            <JsonFormsDispatch
-              uischema={child}
-              schema={schema}
-              path={path}
-              enabled={enabled}
-              renderers={renderers}
-              cells={cells}
-            />
-          )}
-        </Paper>
-      </Grid>
-      <Paper
-        sx={{
-          border: 'none',
-          opacity: isOver ? '1.0' : '0.2',
-          minWidth: '2em',
-          minHeight: '1.5em',
-          // bgcolor: (theme) => (isOver ?  theme. : 'none'),
-        }}
-        ref={dropRef2}
-      >
-        {isOver && isOverCurrent && draggedMeta ? (
-          <Paper sx={{ padding: (theme) => theme.spacing(1, 2), bgcolor: (theme) => theme.palette.secondary.light }}>
-            <DropTargetFormsPreview metadata={draggedMeta} />
-          </Paper>
-        ) : null}
-      </Paper>
+            </Paper>
+          </Grid>
+          <Paper
+            sx={{
+              border: 'none',
+              opacity: isOverCurrent ? '1.0' : '0.2',
+              minWidth: '2em',
+              minHeight: '1.5em',
+              // bgcolor: (theme) => (isOver ?  theme. : 'none'),
+              padding: 4,
+              backgroundColor: isOverCurrent ? 'yellow' : 'red',
+            }}
+            ref={dropRef2}
+          ></Paper>
+        </>
+      )}
     </>
   )
 }

--- a/src/renderer/LayoutPlaceholder.tsx
+++ b/src/renderer/LayoutPlaceholder.tsx
@@ -6,6 +6,8 @@ import React from 'react'
 import { JsonFormsDispatch } from '@jsonforms/react'
 import DropTargetFormsPreview from '../features/dragAndDrop/DropTargetFormsPreview'
 import { useDropTarget } from '../app/hooks'
+import LayoutElement from './LayoutElement'
+import { ArrowForward } from '@mui/icons-material'
 
 type EmptyLayoutElementProps = {
   child: UISchemaElement | undefined
@@ -47,6 +49,11 @@ function LayoutPlaceholder({ child, path, elements, layoutRendererProps, directi
   const { schema, enabled, renderers, cells } = layoutRendererProps
   return (
     <Box>
+      {direction === 'row' && <ArrowForward></ArrowForward>}
+      <StyledPlaceholderElementBox draggedMeta={draggedMeta} handleAllDrop={handleAllDrop} />
+      {/* <Box>
+        <ArrowForward></ArrowForward>
+      </Box>
       <Grid
         container
         spacing={direction === 'row' ? 2 : 0}
@@ -56,20 +63,29 @@ function LayoutPlaceholder({ child, path, elements, layoutRendererProps, directi
         {[0, 1].map((index) => (
           <Grid key={index} item xs>
             {elements && !!elements[index] ? (
-              <JsonFormsDispatch
-                uischema={elements[index]}
+              <LayoutElement
+                direction={direction}
+                key={(path || '') + index}
+                index={index}
+                // @ts-ignore
                 schema={schema}
+                // @ts-ignore
+                visible={true}
+                // @ts-ignore
                 path={path}
+                // @ts-ignore
                 enabled={enabled}
-                renderers={renderers}
+                element={elements[index]}
+                parent={elements}
                 cells={cells}
+                renderers={renderers}
               />
             ) : (
               <StyledPlaceholderElementBox draggedMeta={draggedMeta} handleAllDrop={handleAllDrop} />
             )}
           </Grid>
         ))}
-      </Grid>
+      </Grid> */}
     </Box>
   )
 }

--- a/src/renderer/LayoutPlaceholder.tsx
+++ b/src/renderer/LayoutPlaceholder.tsx
@@ -8,6 +8,7 @@ import DropTargetFormsPreview from '../features/dragAndDrop/DropTargetFormsPrevi
 import { useDropTarget } from '../app/hooks'
 import LayoutElement from './LayoutElement'
 import { ArrowForward } from '@mui/icons-material'
+import LongHorizontalArrow from '../Icons/LongHorizontalArrow'
 
 type EmptyLayoutElementProps = {
   child: UISchemaElement | undefined
@@ -57,7 +58,7 @@ function LayoutPlaceholder({ child, path, elements, layoutRendererProps, directi
   const { schema, enabled, renderers, cells } = layoutRendererProps
   return (
     <Box>
-      {direction === 'row' && <ArrowForward></ArrowForward>}
+      {direction === 'row' && <LongHorizontalArrow></LongHorizontalArrow>}
       <StyledPlaceholderElementBox draggedMeta={draggedMeta} handleAllDrop={handleDropAtStart} />
       {/* <Box>
         <ArrowForward></ArrowForward>

--- a/src/renderer/LayoutPlaceholder.tsx
+++ b/src/renderer/LayoutPlaceholder.tsx
@@ -32,25 +32,33 @@ const StyledPlaceholderElementBox = ({ draggedMeta, handleAllDrop }: StyledPlace
         borderRadius: '5px',
         boxSizing: 'border-box',
         padding: '1em 2em',
+        minWidth: 200,
+        minHeight: 100,
         margin: '1em',
-        '&:hover': {
-          border: `1px dashed green`,
-        },
+        display: 'flex',
+        // '&:hover': {
+        //   border: `1px dashed green`,
+        // },
+        backgroundColor: (theme) => (isOver ? theme.palette.action.focus : 'transparent'),
       }}
     >
-      {isOver && isOverCurrent && draggedMeta ? <DropTargetFormsPreview metadata={draggedMeta} /> : 'placeholder'}
+      {isOver && isOverCurrent && draggedMeta ? (
+        <DropTargetFormsPreview metadata={draggedMeta} />
+      ) : (
+        <span style={{ margin: 'auto' }}> Placeholder</span>
+      )}
     </Box>
   )
 }
 
 function LayoutPlaceholder({ child, path, elements, layoutRendererProps, direction = 'row' }: EmptyLayoutElementProps) {
   //TODO make sure we have child.path
-  const { handleAllDrop, draggedMeta } = useDropTarget({ child, uiSchemaPath: `${(child as any).path}.elements.0` })
+  const { handleDropAtStart, draggedMeta } = useDropTarget({ child, isPlaceholder: true })
   const { schema, enabled, renderers, cells } = layoutRendererProps
   return (
     <Box>
       {direction === 'row' && <ArrowForward></ArrowForward>}
-      <StyledPlaceholderElementBox draggedMeta={draggedMeta} handleAllDrop={handleAllDrop} />
+      <StyledPlaceholderElementBox draggedMeta={draggedMeta} handleAllDrop={handleDropAtStart} />
       {/* <Box>
         <ArrowForward></ArrowForward>
       </Box>

--- a/src/renderer/LayoutWithDropZoneRenderer.tsx
+++ b/src/renderer/LayoutWithDropZoneRenderer.tsx
@@ -1,4 +1,4 @@
-import type { JsonFormsState, UISchemaElement } from '@jsonforms/core'
+import type { JsonFormsState, LabelElement, UISchemaElement } from '@jsonforms/core'
 import {
   composeWithUi,
   ControlElement,
@@ -10,174 +10,14 @@ import {
   OwnPropsOfRenderer,
   Resolve,
 } from '@jsonforms/core'
-import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react'
-import { Box, Grid, IconButton, Paper } from '@mui/material'
+import { useJsonForms } from '@jsonforms/react'
+import { Box, Grid } from '@mui/material'
 import Ajv from 'ajv'
-import isEmpty from 'lodash/isEmpty'
-import React, { ComponentType, FC, MouseEventHandler, ReactNode, useCallback, useMemo } from 'react'
-import { useDrop } from 'react-dnd'
-import { useAppDispatch } from '../app/hooks/reduxHooks'
-import {
-  removeFieldAndLayout,
-  selectEditMode,
-  selectElement,
-  selectSelectedElementKey,
-} from '../features/wizard/WizardSlice'
-import { useSelector } from 'react-redux'
-import { Delete } from '@mui/icons-material'
-import DropTargetFormsPreview from '../features/dragAndDrop/DropTargetFormsPreview'
-import { useDragTarget, useDropTarget } from '../app/hooks'
+
+import React, { ComponentType } from 'react'
+
+import LayoutElement from './LayoutElement'
 import LayoutPlaceholder from './LayoutPlaceholder'
-
-export type RemoveWrapperProps = { editMode: boolean; handleRemove: MouseEventHandler; children: ReactNode }
-const RemoveWrapper: FC<RemoveWrapperProps> = ({ editMode, handleRemove, children }) => {
-  return (
-    <>
-      {editMode ? (
-        <Grid container>
-          <Grid item xs={11}>
-            {children}
-          </Grid>
-          <Grid item xs={1}>
-            <IconButton onClick={handleRemove}>
-              <Delete></Delete>
-            </IconButton>
-          </Grid>
-        </Grid>
-      ) : (
-        children
-      )}
-    </>
-  )
-}
-
-type LayoutElementProps = {
-  index: number
-  direction: 'row' | 'column'
-  state: JsonFormsState
-  schema: JsonSchema
-  visible: boolean
-  path: string
-  enabled: boolean
-  element: UISchemaElement
-  renderers?: JsonFormsRendererRegistryEntry[]
-  cells?: JsonFormsCellRendererRegistryEntry[]
-  parent: UISchemaElement[]
-}
-
-const LayoutElement = ({
-  index,
-  direction,
-  state,
-  schema,
-  path,
-  enabled,
-  element: child,
-  cells,
-  parent,
-  renderers,
-}: LayoutElementProps) => {
-  const rootSchema = getSchema(state)
-  //const rootData = getData(state)
-  const dispatch = useAppDispatch()
-  const editMode = useSelector(selectEditMode)
-  const selectedKey = useSelector(selectSelectedElementKey)
-  const layoutName = useMemo<string | undefined>(
-    () => (child.type === 'Control' ? composeWithUi(child as ControlElement, path) : undefined),
-    [child, path]
-  )
-  const resolvedSchema = useMemo<JsonSchema | undefined>(
-    () =>
-      child.type === 'Control'
-        ? Resolve.schema(schema || rootSchema, (child as ControlElement).scope, rootSchema)
-        : undefined,
-    [schema, rootSchema, child]
-  )
-
-  const key = useMemo<string>(() => (!layoutName ? `layout-${index}` : layoutName), [layoutName, index])
-  const isGroup = useMemo<boolean>(() => child.type === 'Group', [child])
-  const { handleAllDrop, draggedMeta } = useDropTarget({ child })
-
-  const [{ isDragging }, dragRef] = useDragTarget({ child, name: layoutName, resolvedSchema })
-
-  const [{ isOver: isOver1, isOverCurrent: isOverCurrent1 }, dropRef] = useDrop(handleAllDrop, [handleAllDrop])
-  const [{ isOver: isOver2, isOverCurrent: isOverCurrent2 }, dropRef2] = useDrop(handleAllDrop, [handleAllDrop])
-  const isOver = isOver1 || isOver2
-  const isOverCurrent = isOverCurrent1 || isOverCurrent2
-  const handleSelect = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      event.stopPropagation()
-      // @ts-ignore
-      dispatch(selectElement(key))
-    },
-    [dispatch, key]
-  )
-
-  const handleRemove = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      event.stopPropagation()
-      dispatch(removeFieldAndLayout({ path: key }))
-    },
-    [dispatch, key]
-  )
-
-  return (
-    <>
-      <Grid key={key} item ref={dropRef} xs onClick={handleSelect}>
-        <Paper
-          elevation={selectedKey === key ? 4 : 0}
-          sx={{
-            flexGrow: 1,
-            display: isDragging ? 'none' : 'flex',
-            backgroundColor: (theme) => (selectedKey === key ? theme.palette.primary.light : 'none'),
-            padding: (theme) => theme.spacing(1, 2),
-            cursor: 'grab',
-          }}
-          ref={dragRef}
-        >
-          {!isGroup && (
-            <RemoveWrapper handleRemove={handleRemove} editMode={editMode}>
-              <JsonFormsDispatch
-                uischema={child}
-                schema={schema}
-                path={path}
-                enabled={enabled}
-                renderers={renderers}
-                cells={cells}
-              />
-            </RemoveWrapper>
-          )}
-          {isGroup && (
-            <JsonFormsDispatch
-              uischema={child}
-              schema={schema}
-              path={path}
-              enabled={enabled}
-              renderers={renderers}
-              cells={cells}
-            />
-          )}
-        </Paper>
-      </Grid>
-      <Paper
-        sx={{
-          border: 'none',
-          opacity: isOver ? '1.0' : '0.2',
-          minWidth: '2em',
-          minHeight: '1.5em',
-          // bgcolor: (theme) => (isOver ?  theme. : 'none'),
-        }}
-        ref={dropRef2}
-      >
-        {isOver && isOverCurrent && draggedMeta ? (
-          <Paper sx={{ padding: (theme) => theme.spacing(1, 2), bgcolor: (theme) => theme.palette.secondary.light }}>
-            <DropTargetFormsPreview metadata={draggedMeta} />
-          </Paper>
-        ) : null}
-      </Paper>
-    </>
-  )
-}
 
 export interface MaterialLayoutRendererProps extends OwnPropsOfRenderer {
   elements: UISchemaElement[]
@@ -187,9 +27,8 @@ export interface MaterialLayoutRendererProps extends OwnPropsOfRenderer {
 
 const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => {
   const { visible, elements, schema, path, enabled, direction, renderers, cells, uischema } = props
-  const ctx = useJsonForms()
-  const state = { jsonforms: ctx }
-  if ((!elements || elements.length < 2) && visible) {
+
+  if (elements.length === 0 && visible) {
     // @ts-ignore
     return (
       <LayoutPlaceholder
@@ -209,7 +48,6 @@ const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => 
               direction={direction}
               key={(path || '') + index}
               index={index}
-              state={state}
               // @ts-ignore
               schema={schema}
               // @ts-ignore

--- a/src/renderer/LayoutWithDropZoneRenderer.tsx
+++ b/src/renderer/LayoutWithDropZoneRenderer.tsx
@@ -27,7 +27,7 @@ export interface MaterialLayoutRendererProps extends OwnPropsOfRenderer {
 
 const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => {
   const { visible, elements, schema, path, enabled, direction, renderers, cells, uischema } = props
-
+  console.log({ visible, elements, schema, path, enabled, direction, renderers, cells, uischema })
   if (elements.length === 0 && visible) {
     // @ts-ignore
     return (

--- a/src/renderer/LayoutWithDropZoneRenderer.tsx
+++ b/src/renderer/LayoutWithDropZoneRenderer.tsx
@@ -11,6 +11,7 @@ import {
   Resolve,
 } from '@jsonforms/core'
 import { useJsonForms } from '@jsonforms/react'
+import { ArrowForward } from '@mui/icons-material'
 import { Box, Grid } from '@mui/material'
 import Ajv from 'ajv'
 
@@ -42,7 +43,8 @@ const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => 
   } else {
     return (
       <Box sx={{ display: visible ? 'block' : 'none' }}>
-        <Grid container direction={direction} spacing={direction === 'row' ? 2 : 0}>
+        {direction === 'row' && <ArrowForward></ArrowForward>}
+        <Grid container direction={direction} spacing={direction === 'row' ? 0 : 0}>
           {elements.map((element, index) => (
             <LayoutElement
               direction={direction}

--- a/src/renderer/LayoutWithDropZoneRenderer.tsx
+++ b/src/renderer/LayoutWithDropZoneRenderer.tsx
@@ -28,7 +28,7 @@ export interface MaterialLayoutRendererProps extends OwnPropsOfRenderer {
 
 const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => {
   const { visible, elements, schema, path, enabled, direction, renderers, cells, uischema } = props
-  console.log({ visible, elements, schema, path, enabled, direction, renderers, cells, uischema })
+
   if (elements.length === 0 && visible) {
     // @ts-ignore
     return (

--- a/src/renderer/LayoutWithDropZoneRenderer.tsx
+++ b/src/renderer/LayoutWithDropZoneRenderer.tsx
@@ -16,6 +16,7 @@ import { Box, Grid } from '@mui/material'
 import Ajv from 'ajv'
 
 import React, { ComponentType } from 'react'
+import LongHorizontalArrow from '../Icons/LongHorizontalArrow'
 
 import LayoutElement from './LayoutElement'
 import LayoutPlaceholder from './LayoutPlaceholder'
@@ -43,7 +44,7 @@ const MaterialLayoutRendererComponent = (props: MaterialLayoutRendererProps) => 
   } else {
     return (
       <Box sx={{ display: visible ? 'block' : 'none' }}>
-        {direction === 'row' && <ArrowForward></ArrowForward>}
+        {direction === 'row' && <LongHorizontalArrow></LongHorizontalArrow>}
         <Grid container direction={direction} spacing={direction === 'row' ? 0 : 0}>
           {elements.map((element, index) => (
             <LayoutElement

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -87,15 +87,15 @@ export const lgihtThemeOverwrites: Components<Omit<Theme, 'components'>> = {
   },
 }
 export const darkThemeOverwrites: Components<Omit<Theme, 'components'>> = {
-  MuiButton: {
-    styleOverrides: {
-      // Name of the slot
-      root: {
-        // Some CSS
-        fontSize: '1rem',
-      },
-    },
-  },
+  // MuiButton: {
+  //   styleOverrides: {
+  //     // Name of the slot
+  //     root: {
+  //       // Some CSS
+  //       marginRight: 8,
+  //     },
+  //   },
+  // },
 }
 export const agnosticThemeOverwrites: Components<Omit<Theme, 'components'>> = {
   MuiAppBar: {

--- a/src/utils/collectSchemaGargabe.ts
+++ b/src/utils/collectSchemaGargabe.ts
@@ -1,0 +1,43 @@
+import { JsonSchema, resolveSchema, UISchemaElement } from '@jsonforms/core'
+import { cloneDeep } from 'lodash'
+import { getAllScopesInSchema } from './uiSchemaHelpers'
+
+export default function collectSchemaGarbage(jsonschema: JsonSchema, uiSchema: UISchemaElement) {
+  const scopes = getAllScopesInSchema(uiSchema)
+  const marked = cloneDeep(jsonschema)
+  traverseObjects(marked, (obj) => {
+    if (obj.type && !obj.properties) {
+      obj.toBeDeleted = true
+    }
+  })
+
+  for (let scope of scopes) {
+    let resolved = resolveSchema(marked, scope, marked)
+    //@ts-ignore
+    delete resolved.toBeDeleted
+  }
+  traverseDelete(marked)
+  return marked
+}
+
+const traverseObjects = (obj, cb) => {
+  for (let k in obj) {
+    if (obj[k] && typeof obj[k] === 'object') {
+      cb(obj[k])
+
+      traverseObjects(obj[k], cb)
+    }
+  }
+}
+const traverseDelete = (obj) => {
+  for (let k in obj) {
+    if (obj[k] && typeof obj[k] === 'object') {
+      traverseDelete(obj[k])
+      if (obj[k].toBeDeleted) {
+        delete obj[k]
+      } else if (obj[k].properties && Object.keys(obj[k].properties).length === 0) {
+        delete obj[k]
+      }
+    }
+  }
+}

--- a/src/utils/collectSchemaGargabe.ts
+++ b/src/utils/collectSchemaGargabe.ts
@@ -2,9 +2,16 @@ import { JsonSchema, resolveSchema, UISchemaElement } from '@jsonforms/core'
 import { cloneDeep } from 'lodash'
 import { getAllScopesInSchema } from './uiSchemaHelpers'
 
+/**
+ *
+ * @param jsonschema schema to be cleaned
+ * @param uiSchema uiSchema defining the scopes
+ *
+ * @returns jsonschema with all unused properties removed
+ */
 export default function collectSchemaGarbage(jsonschema: JsonSchema, uiSchema: UISchemaElement) {
   const scopes = getAllScopesInSchema(uiSchema)
-  const marked = cloneDeep(jsonschema)
+  const marked = jsonschema
   traverseObjects(marked, (obj) => {
     if (obj.type && !obj.properties) {
       obj.toBeDeleted = true

--- a/src/utils/jsonSchemaHelpers.ts
+++ b/src/utils/jsonSchemaHelpers.ts
@@ -70,6 +70,7 @@ export const deeplyUpdateNestedSchema: (schema: JsonSchema, path: string[], newP
     },
   } as JsonSchema
 }
+
 export const deeplyRemoveNestedProperty: (schema: JsonSchema, path: string) => JsonSchema = (schema, path) => {
   if (!schema.properties) throw new Error(`Schema has no properties`)
   const pathSegments = pathToPathSegments(path)

--- a/src/utils/jsonSchemaHelpers.ts
+++ b/src/utils/jsonSchemaHelpers.ts
@@ -9,6 +9,7 @@ import { pathSegmentsToPath, pathToPathSegments } from './uiSchemaHelpers'
  * @param path path to the nested schema
  * @param newKey new key for the property
  * @param newProperty the property to insert
+ * @param ensurePath  if true, will create the path if it does not exist
  */
 export const deeplySetNestedProperty: (
   schema: JsonSchema,

--- a/src/utils/jsonSchemaHelpers.ts
+++ b/src/utils/jsonSchemaHelpers.ts
@@ -14,8 +14,9 @@ export const deeplySetNestedProperty: (
   schema: JsonSchema,
   path: string[],
   newKey: string,
-  newProperty: JsonSchema
-) => JsonSchema = (schema, path, newKey, newProperty) => {
+  newProperty: JsonSchema,
+  ensurePath?: Boolean
+) => JsonSchema = (schema, path, newKey, newProperty, ensurePath = false) => {
   if (!schema.properties) throw new Error(`Schema has no properties`)
   if (path.length === 0) {
     return {
@@ -28,12 +29,21 @@ export const deeplySetNestedProperty: (
   }
   const [first, ...rest] = path
   const nestedSchema = schema.properties[first]
-  if (!nestedSchema) throw new Error(`Could not find nested schema for ${first}`)
+  if (!nestedSchema && ensurePath) {
+    return {
+      ...schema,
+      properties: {
+        ...schema.properties,
+        [first]: deeplySetNestedProperty({ type: 'object', properties: {} }, rest, newKey, newProperty, ensurePath),
+      },
+    } as JsonSchema
+  }
+  if (!nestedSchema && !ensurePath) throw new Error(`Could not find nested schema for ${first}`)
   return {
     ...schema,
     properties: {
       ...schema.properties,
-      [first]: deeplySetNestedProperty(nestedSchema, rest, newKey, newProperty),
+      [first]: deeplySetNestedProperty(nestedSchema, rest, newKey, newProperty, ensurePath),
     },
   } as JsonSchema
 }

--- a/src/utils/uiSchemaHelpers.ts
+++ b/src/utils/uiSchemaHelpers.ts
@@ -142,6 +142,15 @@ type LayoutWithPath = Layout & { path: string }
 /**
  * recursively add a path, that uniquely identifies a schema element, to a UISchemaElement
  */
+
+/**
+ *
+ * @param uiSchema uiSchema to be extended with paths
+ * @param pathSegments recursive parameter, do not use
+ * @param structurePathSegments recursive parameter, do not us
+ * @returns uiSchema with paths added, that uniquely identify a schema element
+ * e.g. {type: 'Control', scope: '#/properties/foo'} -> {type: 'Control', scope: '#/properties/foo', path: 'elements.0.foo.1', structurePath: 'verticalLayout.0.foo.1'}
+ */
 export const extendUiSchemaWithPath = (
   uiSchema: UISchemaElement,
   pathSegments: string[] = [],

--- a/src/utils/uiSchemaHelpers.ts
+++ b/src/utils/uiSchemaHelpers.ts
@@ -1,4 +1,5 @@
 import { isLayout, Layout, UISchemaElement } from '@jsonforms/core'
+import { current } from '@reduxjs/toolkit'
 import { last } from 'lodash'
 import isEmpty from 'lodash/isEmpty'
 import { ScopableUISchemaElement } from '../types'
@@ -53,6 +54,15 @@ export const insertUISchemaAfterScope = (
     }
     return uischema
   })
+}
+export const getAllScopesInSchema = (uiSchema: UISchemaElement) => {
+  let scopes = []
+  recursivelyMapSchema(uiSchema, (ui: ScopableUISchemaElement) => {
+    console.log(ui)
+    ui.scope && scopes.push(ui.scope)
+    return ui
+  })
+  return scopes
 }
 export const removeUISchemaElement = (scope: string, uiSchema: UISchemaElement) => {
   return recursivelyMapSchema(uiSchema, (uischema) => {

--- a/src/utils/uiSchemaHelpers.ts
+++ b/src/utils/uiSchemaHelpers.ts
@@ -58,7 +58,6 @@ export const insertUISchemaAfterScope = (
 export const getAllScopesInSchema = (uiSchema: UISchemaElement) => {
   let scopes = []
   recursivelyMapSchema(uiSchema, (ui: ScopableUISchemaElement) => {
-    console.log(ui)
     ui.scope && scopes.push(ui.scope)
     return ui
   })

--- a/src/utils/uiSchemaHelpers.ts
+++ b/src/utils/uiSchemaHelpers.ts
@@ -133,7 +133,7 @@ type LayoutWithPath = Layout & { path: string }
  */
 export const extendUiSchemaWithPath = (
   uiSchema: UISchemaElement,
-  pathSegments: string[] = []
+  pathSegments: string[] = ['']
 ): UISchemaElementWithPath | LayoutWithPath => {
   if (isLayout(uiSchema)) {
     const layout = uiSchema as Layout

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,6 +5180,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-css@^5.2.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"


### PR DESCRIPTION
- split insertControl into moveControl and insertControl
- insertControl does no longer handle removing in any way.
- insertControl does not try to handle scoping (which only worked in some cases anyway)
- insertControl can handle inserting at the start of a layout.
- reimplementation of removing, which now only tries to remove what it knows how to remove.
 - instead of eagerly handling schema removal, we just remove ui elements and garbage collect unused schema entries 
- structurePath added to handle scoping in the future. (It does work in a very simple way at the moment.)
- always render a placeholder on empty layouts.
- fixed placeholders in general
- no more previews on hover to eliminate all jitter bugs.
- pretty drop zones 
- show drop zone only when something is moving
- removed unnecessary boxes, 
- added good margins, centering, layouting, making it a little bit more pretty hopefully 🎉 
- content of the form is not editable.
- [ ] create nested schema for groups in ui schema (already implemented some helpers for that, but didnt get it to work correctly)
- [ ] when drop zones spawn, the scrolling should be adjusted to keep the same stuff in the viewport 
